### PR TITLE
Readme updates/clarity

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,8 +263,6 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - name: Checkout
-        uses: actions/checkout@v2
       - name: Delete DynamoDB Item
         uses: mooyoul/dynamodb-actions@v1.2.1
         env:

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ jobs:
     steps:
       - name: Get DynamoDB Item
         id: config
-        uses: mooyoul/dynamodb-actions@1.2.1
+        uses: mooyoul/dynamodb-actions@v1.2.1
         env:
           AWS_DEFAULT_REGION: us-east-1
           AWS_REGION: us-east-1
@@ -86,8 +86,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
+      - name: Checkout
+        uses: actions/checkout@v2
       - name: Put DynamoDB Item
-        uses: mooyoul/dynamodb-actions@1.2.1
+        uses: mooyoul/dynamodb-actions@v1.2.1
         env:
           AWS_DEFAULT_REGION: us-east-1
           AWS_REGION: us-east-1
@@ -116,8 +118,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
+      - name: Checkout
+        uses: actions/checkout@v2
       - name: Put DynamoDB Item
-        uses: mooyoul/dynamodb-actions@1.2.1
+        uses: mooyoul/dynamodb-actions@v1.2.1
         env:
           AWS_DEFAULT_REGION: us-east-1
           AWS_REGION: us-east-1
@@ -167,6 +171,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
+      - name: Checkout
+        uses: actions/checkout@v2
       - name: Put DynamoDB Item
         uses: mooyoul/dynamodb-actions@v1.2.1
         env:
@@ -206,6 +212,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
+      - name: Checkout
+        uses: actions/checkout@v2
       - name: Put DynamoDB Item
         uses: mooyoul/dynamodb-actions@v1.2.1
         env:
@@ -255,6 +263,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
+      - name: Checkout
+        uses: actions/checkout@v2
       - name: Delete DynamoDB Item
         uses: mooyoul/dynamodb-actions@v1.2.1
         env:


### PR DESCRIPTION
Current standalone readme examples do not work as 'v' is missing from version and checkout step is missing for put actions.
Solution:

- Added v to versions
- Added checkout step to put actions